### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>co.ipdata.client</groupId>
   <artifactId>ipdata-java-client</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <description>A java client for ipdata.co</description>
   <name>Ipdata java client</name>
   <url>https://github.com/ipdata/java</url>
@@ -23,7 +23,7 @@
     <connection>scm:git:git@github.com:ipdata/java.git</connection>
     <developerConnection>scm:git:git@github.com:ipdata/java.git</developerConnection>
     <url>https://github.com/ipdata/java</url>
-    <tag>0.2.0</tag>
+    <tag>0.2.1</tag>
   </scm>
   <distributionManagement>
     <repository>


### PR DESCRIPTION
Version 0.2.0 already exists on Maven Central and cannot be re-published. Bump to 0.2.1 for the next release.

https://claude.ai/code/session_01ToqqHtNtg7kdm8TmAMZYe8